### PR TITLE
Restore CNAME plumbing for Pages custom domain

### DIFF
--- a/content/extra/CNAME
+++ b/content/extra/CNAME
@@ -1,0 +1,1 @@
+tomclancy.info

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -89,6 +89,11 @@ SITEURL = "http://localhost:8000"
 
 PATH = "content"
 
+# Copy content/extra/CNAME to the output root so GitHub Pages picks up the
+# custom domain on every deploy.
+STATIC_PATHS = ["images", "extra/CNAME"]
+EXTRA_PATH_METADATA = {"extra/CNAME": {"path": "CNAME"}}
+
 TIMEZONE = "America/New_York"
 
 DEFAULT_LANG = "en"


### PR DESCRIPTION
## Summary
- Adds `content/extra/CNAME` containing `tomclancy.info`
- Wires `STATIC_PATHS` and `EXTRA_PATH_METADATA` so it lands at the output root
- Without this, GitHub Pages clears the custom domain on every deploy because it reads the cname from the deployed artifact

## Test plan
- [ ] After merge, deploy run finishes successfully
- [ ] `curl -I https://tclancy.github.io/pelicantpc/CNAME` returns 200 and body is `tomclancy.info`
- [ ] Pages settings show the custom domain as set (and start cert provisioning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)